### PR TITLE
Fixed package main, fixed README for go import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ package main
 
 import (
 	"fmt"
-	"https://github.com/Beldur/kraken-go-api-client"
+	"github.com/Beldur/kraken-go-api-client"
 )
 
 func main() {

--- a/krakenapi.go
+++ b/krakenapi.go
@@ -1,4 +1,4 @@
-package main
+package krakenapi
 
 import (
 	"crypto/hmac"


### PR DESCRIPTION
Fixed from package main to package krakenapi (unable to go get when main)
Fixed README for example, not needed https://
