### PR TITLE
#6 - add optional http client parameter to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Kraken GO API Client 
+Kraken GO API Client
 ====================
 
 [![build status](https://img.shields.io/travis/beldur/kraken-go-api-client/master.svg)](https://travis-ci.org/beldur/kraken-go-api-client)
@@ -29,7 +29,7 @@ func main() {
 
 	fmt.Printf("Result: %+v\n", result)
 
-	// There also some strongly typed methods available
+	// There are also some strongly typed methods available
 	ticker, err := api.Ticker(krakenapi.XXBTZEUR)
 	if err != nil {
 		log.Fatal(err)
@@ -39,6 +39,9 @@ func main() {
 }
 ```
 
-If you find this useful, you can send me a fraction of a bitcoin!
-
-1Q3P96LcTkbS9VwZkV5ndQa6t4EcR4GzSL
+## Contributors
+ - Piega
+ - Glavic
+ - MarinX
+ - bjorand
+ - [khezen](https://github.com/khezen)

--- a/krakenapi.go
+++ b/krakenapi.go
@@ -60,15 +60,12 @@ type KrakenApi struct {
 }
 
 // New creates a new Kraken API client
-func New(key, secret string, httpClient ...*http.Client) *KrakenApi {
-	var client *http.Client
-	if len(httpClient) > 0 {
-		client = httpClient[0]
-	} else {
-		client = http.DefaultClient
-	}
+func New(key, secret string) *KrakenApi {
+	return NewWithClient(key, secret, http.DefaultClient)
+}
 
-	return &KrakenApi{key, secret, client}
+func NewWithClient(key, secret string, httpClient *http.Client) *KrakenApi {
+	return &KrakenApi{key, secret, httpClient}
 }
 
 // Time returns the server's time

--- a/krakenapi.go
+++ b/krakenapi.go
@@ -60,10 +60,10 @@ type KrakenApi struct {
 }
 
 // New creates a new Kraken API client
-func New(key, secret string, optionalClient ...*http.Client) *KrakenApi {
+func New(key, secret string, httpClient ...*http.Client) *KrakenApi {
 	var client *http.Client
-	if len(optionalClient) > 0 {
-		client = optionalClient[0]
+	if len(httpClient) > 0 {
+		client = httpClient[0]
 	} else {
 		client = http.DefaultClient
 	}

--- a/krakenapi.go
+++ b/krakenapi.go
@@ -60,8 +60,13 @@ type KrakenApi struct {
 }
 
 // New creates a new Kraken API client
-func New(key, secret string) *KrakenApi {
-	client := &http.Client{}
+func New(key, secret string, optionalClient ...*http.Client) *KrakenApi {
+	var client *http.Client
+	if len(optionalClient) > 0 {
+		client = optionalClient[0]
+	} else {
+		client = http.DefaultClient
+	}
 
 	return &KrakenApi{key, secret, client}
 }


### PR DESCRIPTION
add optional *http.Client parameter to existing constructor instead of creating a distinct one.