### PR TITLE
Refactor TradesResponse: Volume is string and Time is integer.

### DIFF
--- a/krakenapi.go
+++ b/krakenapi.go
@@ -137,18 +137,19 @@ func (api *KrakenApi) Trades(pair string, since int64) (*TradesResponse, error) 
 	trades := v[pair].([]interface{})
 	for _, v := range trades {
 		trade := v.([]interface{})
+
 		priceString := trade[0].(string)
 		price, _ := strconv.ParseFloat(priceString, 64)
+
+		volumeString := trade[1].(string)
 		volume, _ := strconv.ParseFloat(trade[1].(string), 64)
-		priceParts := strings.Split(priceString, ".")
-		priceInt, _ := strconv.ParseInt(priceParts[0]+priceParts[1], 10, 64)
 
 		tradeInfo := TradeInfo{
-			Price:         trade[0].(string),
+			Price:         priceString,
 			PriceFloat:    price,
-			PriceInt:      priceInt,
-			Volume:        volume,
-			Time:          trade[2].(float64),
+			Volume:        volumeString,
+			VolumeFloat:   volume,
+			Time:          int64(trade[2].(float64)),
 			Buy:           trade[3].(string) == BUY,
 			Sell:          trade[3].(string) == SELL,
 			Market:        trade[4].(string) == MARKET,

--- a/types.go
+++ b/types.go
@@ -1,13 +1,13 @@
 package krakenapi
 
 const (
-	DASHEUR = "DASHEUR"
-	DASHUSD = "DASHUSD"
-	DASHXBT = "DASHXBT"
-	GNOETH = "GNOETH"
-	GNOEUR = "GNOEUR"
-	GNOUSD = "GNOUSD"
-	GNOXBT = "GNOXBT"
+	DASHEUR  = "DASHEUR"
+	DASHUSD  = "DASHUSD"
+	DASHXBT  = "DASHXBT"
+	GNOETH   = "GNOETH"
+	GNOEUR   = "GNOEUR"
+	GNOUSD   = "GNOUSD"
+	GNOXBT   = "GNOXBT"
 	USDTZUSD = "USDTZUSD"
 	XETCXETH = "XETCXETH"
 	XETCXXBT = "XETCXXBT"
@@ -50,7 +50,7 @@ const (
 	XZECXXBT = "XZECXXBT"
 	XZECZEUR = "XZECZEUR"
 	XZECZUSD = "XZECZUSD"
-	)
+)
 
 const (
 	BUY    = "b"
@@ -75,13 +75,13 @@ type TimeResponse struct {
 
 // AssetPairsResponse includes asset pair informations
 type AssetPairsResponse struct {
-	DASHEUR AssetPairInfo
-	DASHUSD AssetPairInfo
-	DASHXBT AssetPairInfo
-	GNOETH AssetPairInfo
-	GNOEUR AssetPairInfo
-	GNOUSD AssetPairInfo
-	GNOXBT AssetPairInfo
+	DASHEUR  AssetPairInfo
+	DASHUSD  AssetPairInfo
+	DASHXBT  AssetPairInfo
+	GNOETH   AssetPairInfo
+	GNOEUR   AssetPairInfo
+	GNOUSD   AssetPairInfo
+	GNOXBT   AssetPairInfo
 	USDTZUSD AssetPairInfo
 	XETCXETH AssetPairInfo
 	XETCXXBT AssetPairInfo
@@ -165,7 +165,7 @@ type AssetPairInfo struct {
 // AssetsResponse includes asset informations
 type AssetsResponse struct {
 	DASH AssetInfo
-	GNO AssetInfo
+	GNO  AssetInfo
 	KFEE AssetInfo
 	USDT AssetInfo
 	XDAO AssetInfo
@@ -233,13 +233,13 @@ type BalanceResponse struct {
 
 // TickerResponse includes the requested ticker pairs
 type TickerResponse struct {
-	DASHEUR PairTickerInfo
-	DASHUSD PairTickerInfo
-	DASHXBT PairTickerInfo
-	GNOETH PairTickerInfo
-	GNOEUR PairTickerInfo
-	GNOUSD PairTickerInfo
-	GNOXBT PairTickerInfo
+	DASHEUR  PairTickerInfo
+	DASHUSD  PairTickerInfo
+	DASHXBT  PairTickerInfo
+	GNOETH   PairTickerInfo
+	GNOEUR   PairTickerInfo
+	GNOUSD   PairTickerInfo
+	GNOXBT   PairTickerInfo
 	USDTZUSD PairTickerInfo
 	XETCXETH PairTickerInfo
 	XETCXXBT PairTickerInfo
@@ -316,9 +316,9 @@ type TradesResponse struct {
 type TradeInfo struct {
 	Price         string
 	PriceFloat    float64
-	PriceInt      int64
-	Volume        float64
-	Time          float64
+	Volume        string
+	VolumeFloat   float64
+	Time          int64
 	Buy           bool
 	Sell          bool
 	Market        bool


### PR DESCRIPTION
Reply to this commit: https://github.com/beldur/kraken-go-api-client/commit/0d429b84b3978e1a9f8216072eb8411e6acbe136

`PriceInt` was wrong, since it should be same exponent (let say e^10) for all prices; so I have dropped that solution; let API consumer decide what to do with it.

`Time` is original integer, but unmarshal returns it as `format64`. So I have changed it back to `int64`.