### PR TITLE
updated order constants to current api standard

### DIFF
--- a/types.go
+++ b/types.go
@@ -65,10 +65,10 @@ const (
 )
 
 const (
-	BUY    = "b"
-	SELL   = "s"
-	MARKET = "m"
-	LIMIT  = "l"
+	BUY    = "buy"
+	SELL   = "sell"
+	MARKET = "market"
+	LIMIT  = "limit"
 )
 
 // KrakenResponse wraps the Kraken API JSON response


### PR DESCRIPTION
Some constants weren't compatible with the arguments required for the API call.