### PR TITLE
fixed test format error

### DIFF
--- a/krakenapi_test.go
+++ b/krakenapi_test.go
@@ -129,10 +129,10 @@ func TestQueryDepth(t *testing.T) {
 	}
 
 	if len(result.Asks) > count {
-		t.Errorf("Asks length must be less than count , got %s > %s", len(result.Asks), count)
+		t.Errorf("Asks length must be less than count , got %d > %d", len(result.Asks), count)
 	}
 
 	if len(result.Bids) > count {
-		t.Errorf("Bids length must be less than count , got %s > %s", len(result.Bids), count)
+		t.Errorf("Bids length must be less than count , got %d > %d", len(result.Bids), count)
 	}
 }


### PR DESCRIPTION
The tests were calling `Errorf` with inappropriate formatting.