### PR TITLE
userref is a number

### DIFF
--- a/types.go
+++ b/types.go
@@ -397,7 +397,7 @@ type OrderDescription struct {
 type Order struct {
 	TransactionID  string           `json:"-"`
 	ReferenceID    string           `json:"refid"`
-	UserRef        string           `json:"userref"`
+	UserRef        int              `json:"userref"`
 	Status         string           `json:"status"`
 	OpenTime       float64          `json:"opentm"`
 	StartTime      float64          `json:"starttm"`


### PR DESCRIPTION
I have found it: "userref = user reference id.  32-bit signed number" at https://www.kraken.com/help/api#get-open-orders