### PR TITLE
add userref to AddOrder()

### DIFF
--- a/krakenapi.go
+++ b/krakenapi.go
@@ -344,6 +344,9 @@ func (api *KrakenApi) AddOrder(pair string, direction string, orderType string, 
 	if value, ok := args["trading_agreement"]; ok {
 		params.Add("trading_agreement", value)
 	}
+	if value, ok := args["userref"]; ok {
+		params.Add("userref", value)
+	}
 	resp, err := api.queryPrivate("AddOrder", params, &AddOrderResponse{})
 
 	if err != nil {


### PR DESCRIPTION
The Kraken API has a field called userref that can be used to "tag" an order so that it can be retrieved easily later on. See https://support.kraken.com/hc/en-us/articles/360000938763-Use-of-the-userref-parameter for a more detailed description.