### PR TITLE
ClosedOrders: adding support for trade ids

### DIFF
--- a/krakenapi_test.go
+++ b/krakenapi_test.go
@@ -2,6 +2,7 @@ package krakenapi
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net/url"
 	"reflect"
 	"testing"
@@ -135,4 +136,78 @@ func TestQueryDepth(t *testing.T) {
 	if len(result.Bids) > count {
 		t.Errorf("Bids length must be less than count , got %d > %d", len(result.Bids), count)
 	}
+}
+
+func TestUnmarshalClosedOrder(t *testing.T) {
+	body := []byte(`
+	{
+		"error": [],
+		"result": {
+			"closed": {
+				"AAAAAA-BBBBB-CCCCCC": {
+					"refid": null,
+					"userref": 1000000000,
+					"status": "closed",
+					"reason": null,
+					"opentm": 1000000000.5194,
+					"closetm": 1000000000.5288,
+					"starttm": 0,
+					"expiretm": 1200000000,
+					"descr": {
+						"pair": "ETHEUR",
+						"type": "sell",
+						"ordertype": "market",
+						"price": "0",
+						"price2": "0",
+						"leverage": "none",
+						"order": "sell 0.02000000 ETHEUR @ market",
+						"close": ""
+					},
+					"vol": "0.02000000",
+					"vol_exec": "0.02000000",
+					"cost": "2.95",
+					"fee": "0",
+					"price": "147.55",
+					"stopprice": "0.00000",
+					"limitprice": "0.00000",
+					"misc": "",
+					"oflags": "fciq",
+					"trades": [
+						"DDDDDD-EEEEE-FFFFFF"
+					]
+				}
+			},
+			"count": 1
+		}
+	}
+	`)
+
+	var jsonData KrakenResponse
+	if err := json.Unmarshal(body, &jsonData); err != nil {
+		t.Error(err)
+	}
+
+	result, err := json.Marshal(jsonData.Result)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var closedOrders ClosedOrdersResponse
+	if err := json.Unmarshal(result, &closedOrders); err != nil {
+		t.Error(err)
+	}
+
+	if closedOrders.Count != 1 {
+		t.Error("count should be 1")
+	}
+
+	order, ok := closedOrders.Closed["AAAAAA-BBBBB-CCCCCC"]
+	if !ok {
+		t.Error("order id AAAAAA-BBBBB-CCCCCC should exist")
+	}
+
+	if order.TradesID[0] != "DDDDDD-EEEEE-FFFFFF" {
+		t.Error("trades[0] id should be DDDDDD-EEEEE-FFFFFF")
+	}
+
 }

--- a/types.go
+++ b/types.go
@@ -535,6 +535,7 @@ type Order struct {
 	OrderFlags     string           `json:"oflags"`
 	CloseTime      float64          `json:"closetm"`
 	Reason         string           `json:"reason"`
+	TradesID       []string         `json:"trades"`
 }
 
 // ClosedOrdersResponse represents a list of closed orders, indexed by id

--- a/types.go
+++ b/types.go
@@ -529,7 +529,7 @@ type Order struct {
 	Cost           float64          `json:"cost,string"`
 	Fee            float64          `json:"fee,string"`
 	Price          float64          `json:"price,string"`
-	StopPrice      float64          `json:"stopprice.string"`
+	StopPrice      float64          `json:"stopprice,string"`
 	LimitPrice     float64          `json:"limitprice,string"`
 	Misc           string           `json:"misc"`
 	OrderFlags     string           `json:"oflags"`


### PR DESCRIPTION
currently the [order struct](https://github.com/salanfe/kraken-go-api-client/blob/4b7e23e5fe98af8126075f81cf33a4ef7a7ad791/types.go#L518)  does not support trades id https://www.kraken.com/features/api#get-open-orders if input value `trades` is set to `true`

annexe question: why using `float64` and not `string` for `VolumeExecuted`, `Cost`, ... `Price`, etc ? I would prefer getting those as strings and using the `decimal` package in my app if I feel the need to (for example). And why leaving `Volume` in string ? Is this a lack of consistency or I am missing something ? thx :) 