### PR TITLE
set type of WithdrawResponse.RefID to string

### DIFF
--- a/types.go
+++ b/types.go
@@ -481,7 +481,7 @@ type DepositAddressesResponse []struct {
 
 // WithdrawResponse is the response type of a Withdraw query to the Kraken API.
 type WithdrawResponse struct {
-	RefID int `json:"refid"`
+	RefID string `json:"refid"`
 }
 
 // WithdrawInfoResponse is the response type showing withdrawal information for a selected withdrawal method.


### PR DESCRIPTION
This MR changes the type if RefID in WithdrawResponse to `string` as this is the correct return format of the API (fixes issue #49).