### PR TITLE
Adding API call to get open positions

### DIFF
--- a/krakenapi.go
+++ b/krakenapi.go
@@ -341,6 +341,31 @@ func (api *KrakenAPI) OpenOrders(args map[string]string) (*OpenOrdersResponse, e
 	return resp.(*OpenOrdersResponse), nil
 }
 
+// OpenPositions returns all open orders
+func (api *KrakenAPI) OpenPositions(args map[string]string) (*OpenPositionsResponse, error) {
+	params := url.Values{}
+	if value, ok := args["txid"]; ok {
+		params.Add("txid", value)
+	}
+	if value, ok := args["docalcs"]; ok {
+		params.Add("docalcs", value)
+	}
+	if value, ok := args["consolidation"]; ok {
+		params.Add("consolidation", value)
+	}
+	if value, ok := args["market"]; ok {
+		params.Add("market", value)
+	}
+
+	resp, err := api.queryPrivate("OpenPositions", params, &OpenPositionsResponse{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*OpenPositionsResponse), nil
+}
+
 // ClosedOrders returns all closed orders
 func (api *KrakenAPI) ClosedOrders(args map[string]string) (*ClosedOrdersResponse, error) {
 	params := url.Values{}

--- a/krakenapi.go
+++ b/krakenapi.go
@@ -72,6 +72,7 @@ var privateMethods = []string{
 // These represent the minimum order sizes for the respective coins
 // Should be monitored through here: https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size-
 const (
+	MinimumAAVE = 0.1
 	MinimumREP  = 0.3
 	MinimumXBT  = 0.002
 	MinimumBCH  = 0.002

--- a/types.go
+++ b/types.go
@@ -655,15 +655,16 @@ type Position struct {
 	TradeTime          float64 `json:"time"`
 	PositionType       string  `json:"type"`
 	OrderType          string  `json:"ordertype"`
-	Cost               float64 `json:"cost"`
-	Fee                float64 `json:"fee"`
-	Volume             string  `json:"vol"`
-	VolumeClosed       string  `json:"vol_closed"`
-	Margin             float64 `json:"margin"`
-	Value              float64 `json:"value"`
-	Net                float64 `json:"net"`
+	Cost               float64 `json:"cost,string"`
+	Fee                float64 `json:"fee,string"`
+	Volume             float64 `json:"vol,string"`
+	VolumeClosed       float64 `json:"vol_closed,string"`
+	Margin             float64 `json:"margin,string"`
+	Value              float64 `json:"value,string"`
+	Net                float64 `json:"net,string"`
 	Misc               string  `json:"misc"`
 	OrderFlags         string  `json:"oflags"`
+	Status             string  `json:"posstatus"`
 }
 
 // ClosedOrdersResponse represents a list of closed orders, indexed by id

--- a/types.go
+++ b/types.go
@@ -16,6 +16,7 @@ const (
 	ADAEUR   = "ADAEUR"
 	ADAUSD   = "ADAUSD"
 	ADAXBT   = "ADAXBT"
+	AAVEUSD  = "AAVEUSD"
 	BCHEUR   = "BCHEUR"
 	BCHUSD   = "BCHUSD"
 	BCHXBT   = "BCHXBT"
@@ -110,6 +111,7 @@ type TimeResponse struct {
 // AssetPairsResponse includes asset pair informations
 type AssetPairsResponse struct {
 	ADACAD   AssetPairInfo
+	AAVEUSD  AssetPairInfo
 	ADAETH   AssetPairInfo
 	ADAEUR   AssetPairInfo
 	ADAUSD   AssetPairInfo
@@ -221,6 +223,7 @@ type AssetPairInfo struct {
 // AssetsResponse includes asset informations
 type AssetsResponse struct {
 	ADA  AssetInfo
+	AAVE AssetInfo
 	BCH  AssetInfo
 	DASH AssetInfo
 	EOS  AssetInfo
@@ -267,6 +270,7 @@ type AssetInfo struct {
 // BalanceResponse represents the account's balances (list of currencies)
 type BalanceResponse struct {
 	ADA  float64 `json:"ADA,string"`
+	AAVE float64 `json:"AAVE,string"`
 	BCH  float64 `json:"BCH,string"`
 	DASH float64 `json:"DASH,string"`
 	EOS  float64 `json:"EOS,string"`
@@ -319,6 +323,7 @@ type Fees struct {
 	ADAEUR   FeeInfo
 	ADAUSD   FeeInfo
 	ADAXBT   FeeInfo
+	AAVEUSD  FeeInfo
 	BCHEUR   FeeInfo
 	BCHUSD   FeeInfo
 	BCHXBT   FeeInfo
@@ -412,6 +417,7 @@ type TickerResponse struct {
 	ADAEUR   PairTickerInfo
 	ADAUSD   PairTickerInfo
 	ADAXBT   PairTickerInfo
+	AAVEUSD  PairTickerInfo
 	BCHEUR   PairTickerInfo
 	BCHUSD   PairTickerInfo
 	BCHXBT   PairTickerInfo

--- a/types.go
+++ b/types.go
@@ -658,7 +658,7 @@ type Position struct {
 	Cost               float64 `json:"cost"`
 	Fee                float64 `json:"fee"`
 	Volume             string  `json:"vol"`
-	VolumeClosed       string  `json:"vol_closed,string"`
+	VolumeClosed       string  `json:"vol_closed"`
 	Margin             float64 `json:"margin"`
 	Value              float64 `json:"value"`
 	Net                float64 `json:"net"`

--- a/types.go
+++ b/types.go
@@ -647,6 +647,25 @@ type Order struct {
 	Reason         string           `json:"reason"`
 }
 
+// Position - Represents a single position
+type Position struct {
+	TransactionID      string  `json:"-"`
+	OrderTransactionID string  `json:"ordertxid"`
+	Pair               string  `json:"pair"`
+	TradeTime          float64 `json:"time"`
+	PositionType       string  `json:"type"`
+	OrderType          string  `json:"ordertype"`
+	Cost               float64 `json:"cost"`
+	Fee                float64 `json:"fee"`
+	Volume             string  `json:"vol"`
+	VolumeClosed       string  `json:"vol_closed,string"`
+	Margin             float64 `json:"margin"`
+	Value              float64 `json:"value"`
+	Net                float64 `json:"net"`
+	Misc               string  `json:"misc"`
+	OrderFlags         string  `json:"oflags"`
+}
+
 // ClosedOrdersResponse represents a list of closed orders, indexed by id
 type ClosedOrdersResponse struct {
 	Closed map[string]Order `json:"closed"`
@@ -699,6 +718,9 @@ type OpenOrdersResponse struct {
 	Open  map[string]Order `json:"open"`
 	Count int              `json:"count"`
 }
+
+// OpenPositionsResponse response when querying the open positions https://www.kraken.com/features/api#get-open-positions
+type OpenPositionsResponse map[string]Position
 
 // AddOrderResponse response when adding an order
 type AddOrderResponse struct {


### PR DESCRIPTION
Using these patches you can now request the open positions from the Kraken API.

Minor addition - Adding a minimum AAVE constant as well.
