### PR TITLE
Add Ordermin to AssetPairInfo

### DIFF
--- a/types.go
+++ b/types.go
@@ -218,6 +218,8 @@ type AssetPairInfo struct {
 	MarginCall int `json:"margin_call"`
 	// Stop-out/Liquidation margin level
 	MarginStop int `json:"margin_stop"`
+	// Order minimum
+	OrderMin float64 `json:"ordermin"`
 }
 
 // AssetsResponse includes asset informations


### PR DESCRIPTION
Based on the current Kraken API documentation: https://api.kraken.com/0/public/AssetPairs

Also ensures that we no longer need to check https://support.kraken.com/hc/en-us/articles/205893708-What-is-the-minimum-order-size- , as some `Minimum...` are outdated