### PR TITLE
Use GET requests instead of POST (which have been deprecated)

### DIFF
--- a/krakenapi.go
+++ b/krakenapi.go
@@ -610,7 +610,7 @@ func (api *KrakenAPI) queryPrivate(method string, values url.Values, typ interfa
 func (api *KrakenAPI) doRequest(reqURL string, values url.Values, headers map[string]string, typ interface{}) (interface{}, error) {
 
 	// Create request
-	req, err := http.NewRequest("POST", reqURL, strings.NewReader(values.Encode()))
+	req, err := http.NewRequest(http.MethodGet, reqURL, strings.NewReader(values.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("Could not execute request! #1 (%s)", err.Error())
 	}


### PR DESCRIPTION
As per https://docs.kraken.com/rest/

> Note: As of 31st Jan 2024, the undocumented use of POST requests to /0/public/* endpoints will be deprecated to improve the performance of our systems and experience for consumers of the API. The endpoints will now return a 4xx error when accessed with a POST request instead of a GET.